### PR TITLE
Hook Up Signup / Login Pages to Graphcool Email Auth Integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   "dependencies": {
     "apollo-boost": "^0.1.6",
     "apollo-link": "^1.2.2",
+    "apollo-link-context": "^1.0.8",
     "apollo-link-state": "^0.4.1",
     "axios": "^0.18.0",
+    "formik": "^1.0.2",
     "graphql": "^0.13.2",
     "lodash": "^4.17.10",
     "normalize.css": "^8.0.0",

--- a/src/components/atoms/ButtonSignout/index.jsx
+++ b/src/components/atoms/ButtonSignout/index.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { signOut } from "util/loginUtils";
+import { withApollo } from "react-apollo";
+
+class ButtonSignout extends React.Component {
+  handleClick = () => {
+    signOut();
+    this.props.client.resetStore();
+  };
+  render() {
+    return <button onClick={this.handleClick}>Sign Out</button>;
+  }
+}
+
+export default withApollo(ButtonSignout);

--- a/src/components/atoms/index.js
+++ b/src/components/atoms/index.js
@@ -12,3 +12,4 @@ export { default as ListLink } from "./ListLink";
 export { default as TextVisibility } from "./TextVisibility";
 export { default as AngleBracket } from "./AngleBracket";
 export { default as ButtonSubmit } from "./ButtonSubmit";
+export { default as ButtonSignout } from "./ButtonSignout";

--- a/src/components/molecules/index.js
+++ b/src/components/molecules/index.js
@@ -1,4 +1,3 @@
 export { default as Comment } from "./Comment";
-export { default as LoginBtn } from "./LoginBtn";
 export { default as Post } from "./Post";
 export { default as FormItem } from "./FormItem";

--- a/src/components/organisms/Footer/index.jsx
+++ b/src/components/organisms/Footer/index.jsx
@@ -1,12 +1,9 @@
 import React from "react";
-import { LoginBtn } from "components/molecules";
 import { Wrapper, StyledFooter } from "styles";
 
 const Footer = () => (
   <Wrapper>
-    <StyledFooter>
-      <LoginBtn />
-    </StyledFooter>
+    <StyledFooter />
   </Wrapper>
 );
 

--- a/src/components/organisms/LoginForm/LoginForm.jsx
+++ b/src/components/organisms/LoginForm/LoginForm.jsx
@@ -3,45 +3,45 @@ import { StyledForm, StyledLink, StyledFormText } from "styles";
 import { FormItem } from "components/molecules";
 import { ButtonSubmit } from "components/atoms";
 import { withRouter } from "react-router-dom";
+import { signIn } from "util/loginUtils";
+import { withApollo } from "react-apollo";
 
 class LoginForm extends Component {
   state = {
-    username: "",
+    email: "",
     password: ""
   };
 
   handleChange = ({ target }) => {
-    this.setState({ [target.id]: [target.value] });
+    this.setState({ [target.id]: target.value });
   };
 
   handleSubmit = e => {
     e.preventDefault();
     const { userInfo, toggleTestAuth } = this.props;
     const { notifications, imageUrl, messages } = userInfo;
-    const username = this.state.username;
-    toggleTestAuth({
-      variables: {
-        isAuthenticated: !userInfo.isAuthenticated,
-        notifications,
-        imageUrl,
-        messages,
-        username
-      }
-    }).then(() => {
-      this.props.history.push("/home");
-    });
+    const { email, password } = this.state;
+    this.props
+      .loginUser({
+        variables: { email, password }
+      })
+      .then(data => {
+        signIn(data.data.signinUser.token);
+        this.props.client.resetStore();
+        this.props.history.push("/home");
+      });
   };
 
   render() {
     const { handleChange, handleSubmit } = this;
-    const { username, password } = this.state;
+    const { email, password } = this.state;
     return (
       <StyledForm onSubmit={handleSubmit}>
         <FormItem
-          labelText="Username: "
-          value={username}
-          name="username"
-          type="text"
+          labelText="Email: "
+          value={email}
+          name="email"
+          type="email"
           handleChange={handleChange}
         />
         <FormItem
@@ -60,4 +60,4 @@ class LoginForm extends Component {
   }
 }
 
-export default withRouter(LoginForm);
+export default withRouter(withApollo(LoginForm));

--- a/src/components/organisms/LoginForm/LoginForm.jsx
+++ b/src/components/organisms/LoginForm/LoginForm.jsx
@@ -19,7 +19,7 @@ class LoginForm extends Component {
   handleSubmit = e => {
     e.preventDefault();
     const { userInfo, toggleTestAuth } = this.props;
-    const { notifications, imageUrl, messages } = userInfo;
+    // const { notifications, imageUrl, messages } = userInfo;
     const { email, password } = this.state;
     this.props
       .loginUser({

--- a/src/components/organisms/LoginForm/index.jsx
+++ b/src/components/organisms/LoginForm/index.jsx
@@ -1,15 +1,16 @@
 import { compose, graphql } from "react-apollo";
 
 import LoginForm from "./LoginForm";
-import { TOGGLE_TEST_AUTH } from "state/mutations";
+import { TOGGLE_TEST_AUTH, LOGIN_USER } from "state/mutations";
 import { GET_TEST_AUTH } from "state/queries";
 
-export default compose(
-  graphql(TOGGLE_TEST_AUTH, {
-    name: "toggleTestAuth",
-    refetchQueries: ["getAuthUser"]
-  }),
-  graphql(GET_TEST_AUTH, {
-    props: ({ data }) => ({ ...data })
-  })
-)(LoginForm);
+export default compose(graphql(LOGIN_USER, { name: "loginUser" }))(LoginForm);
+
+// Client State Test Queries/Mutations
+// graphql(TOGGLE_TEST_AUTH, {
+//   name: "toggleTestAuth",
+//   refetchQueries: ["getAuthUser"]
+// }),
+// graphql(GET_TEST_AUTH, {
+//   props: ({ data }) => ({ ...data })
+// })

--- a/src/components/organisms/NavBar/NavBar/RightNav.jsx
+++ b/src/components/organisms/NavBar/NavBar/RightNav.jsx
@@ -1,18 +1,19 @@
-import React from "react";
-import { ListLink, TextVisibility } from "components/atoms";
+import React, { Fragment } from "react";
+import { ListLink, TextVisibility, ButtonSignout } from "components/atoms";
 import { Home } from "components/atoms/Icons";
-
 import { NavItemContainer, StyledList } from "styles";
 import SubNavNoAuth from "./SubNavNoAuth";
 import SubNavWithAuth from "./SubNavWithAuth";
 
-const RightNav = ({ userInfo }) => {
-  console.log(userInfo);
+const RightNav = ({ user }) => {
   return (
     <StyledList>
       <ListLink to="/home" render={<HomeView />} />
-      {userInfo.isAuthenticated ? (
-        <SubNavWithAuth {...userInfo} />
+      {user ? (
+        <Fragment>
+          <SubNavWithAuth {...user} />
+          <ButtonSignout />
+        </Fragment>
       ) : (
         <SubNavNoAuth />
       )}

--- a/src/components/organisms/NavBar/NavBar/index.jsx
+++ b/src/components/organisms/NavBar/NavBar/index.jsx
@@ -3,12 +3,12 @@ import { StyledNavigation } from "styles";
 import LeftNav from "./LeftNav";
 import RightNav from "./RightNav";
 
-const NavBar = ({ userInfo }) => {
-  console.log(userInfo);
+const NavBar = ({ user }) => {
+  console.log(user);
   return (
     <StyledNavigation>
       <LeftNav appName="Wobbly" />
-      <RightNav userInfo={userInfo} />
+      <RightNav user={user} />
     </StyledNavigation>
   );
 };

--- a/src/components/organisms/NavBar/index.jsx
+++ b/src/components/organisms/NavBar/index.jsx
@@ -1,9 +1,19 @@
 import NavBar from "./NavBar";
 import { graphql, compose } from "react-apollo";
 import { GET_TEST_AUTH } from "state/queries";
+import gql from "graphql-tag";
+
+const GET_USER = gql`
+  query getUser {
+    user {
+      username
+      imageUrl
+    }
+  }
+`;
 
 export default compose(
-  graphql(GET_TEST_AUTH, {
+  graphql(GET_USER, {
     props: ({ data }) => ({ ...data })
   })
 )(NavBar);

--- a/src/components/organisms/SignupForm/SignupForm.jsx
+++ b/src/components/organisms/SignupForm/SignupForm.jsx
@@ -1,0 +1,114 @@
+import React, { Component } from "react";
+import {
+  StyledForm,
+  StyledLink,
+  StyledFormText,
+  StyledFormError
+} from "styles";
+import { FormItem } from "components/molecules";
+import { ButtonSubmit } from "components/atoms";
+import { withFormik } from "formik";
+import { validateSignup, catchGqlErrors } from "util/functions";
+import { withRouter } from "react-router-dom";
+import { signIn } from "util/loginUtils";
+import { withApollo } from "react-apollo";
+
+const InnerForm = ({
+  values,
+  errors,
+  touched,
+  handleChange,
+  handleSubmit,
+  handleBlur,
+  isSubmitting
+}) => (
+  <StyledForm onSubmit={handleSubmit}>
+    <FormItem
+      labelText="Username: "
+      value={values.username}
+      name="username"
+      type="text"
+      onBlur={handleBlur}
+      handleChange={handleChange}
+    />
+    {touched.username &&
+      errors.username && <StyledFormError>{errors.username}</StyledFormError>}
+    <FormItem
+      labelText="Email: "
+      value={values.email}
+      name="email"
+      type="email"
+      onBlur={handleBlur}
+      handleChange={handleChange}
+    />
+    {touched.email &&
+      errors.email && <StyledFormError>{errors.email}</StyledFormError>}
+    <FormItem
+      labelText="Password: "
+      value={values.password}
+      name="password"
+      type="password"
+      onBlur={handleBlur}
+      handleChange={handleChange}
+    />
+    {touched.password &&
+      errors.password && <StyledFormError>{errors.password}</StyledFormError>}
+    <FormItem
+      labelText="Password Confirmation: "
+      value={values.passwordConf}
+      name="passwordConf"
+      type="password"
+      onBlur={handleBlur}
+      handleChange={handleChange}
+    />
+    {touched.passwordConf &&
+      errors.passwordConf && (
+        <StyledFormError>{errors.passwordConf}</StyledFormError>
+      )}
+    <ButtonSubmit text="Register" />
+    <StyledFormText>
+      Already have an account? <StyledLink to="/login">Log In</StyledLink>
+    </StyledFormText>
+  </StyledForm>
+);
+
+const SignupForm = withFormik({
+  mapPropsToValues: props => ({
+    username: "",
+    email: "",
+    password: "",
+    passwordConf: ""
+  }),
+  validate: validateSignup,
+  handleSubmit: (
+    { username, password, email },
+    { props, setSubmitting, setErrors }
+  ) => {
+    props
+      .signupUser({
+        variables: {
+          username,
+          email,
+          password
+        }
+      })
+      .then(() => {
+        props
+          .loginUser({
+            variables: {
+              email,
+              password
+            }
+          })
+          .then(data => {
+            signIn(data.data.signinUser.token);
+            props.client.resetStore();
+            props.history.push("/home");
+          })
+          .catch(err => setErrors(catchGqlErrors(err)));
+      })
+      .catch(err => setErrors(catchGqlErrors(err)));
+  }
+})(InnerForm);
+
+export default withRouter(withApollo(SignupForm));

--- a/src/components/organisms/SignupForm/index.jsx
+++ b/src/components/organisms/SignupForm/index.jsx
@@ -1,63 +1,12 @@
-import React, { Component } from "react";
-import { StyledForm, StyledLink, StyledFormText } from "styles";
-import { FormItem } from "components/molecules";
-import { ButtonSubmit } from "components/atoms";
+import SignupForm from "./SignupForm";
+import { compose, graphql } from "react-apollo";
+import { SIGNUP_USER, LOGIN_USER } from "state/mutations";
 
-export default class SignupForm extends Component {
-  state = {
-    username: "",
-    email: "",
-    password: "",
-    passwordConf: ""
-  };
-
-  handleChange = ({ target }) => {
-    this.setState({ [target.id]: [target.value] });
-  };
-
-  handleSubmit = e => {
-    e.preventDefault();
-  };
-
-  render() {
-    const { handleChange, handleSubmit } = this;
-    const { username, email, password, passwordConf } = this.state;
-
-    return (
-      <StyledForm onSubmit={handleSubmit}>
-        <FormItem
-          labelText="Username: "
-          value={username}
-          name="username"
-          type="text"
-          handleChange={handleChange}
-        />
-        <FormItem
-          labelText="Email: "
-          value={email}
-          name="email"
-          type="text"
-          handleChange={handleChange}
-        />
-        <FormItem
-          labelText="Password: "
-          value={password}
-          name="password"
-          type="password"
-          handleChange={handleChange}
-        />
-        <FormItem
-          labelText="Password Confirmation: "
-          value={passwordConf}
-          name="passwordConf"
-          type="passwordConf"
-          handleChange={handleChange}
-        />
-        <ButtonSubmit text="Register" />
-        <StyledFormText>
-          Already have an account? <StyledLink to="/login">Log In</StyledLink>
-        </StyledFormText>
-      </StyledForm>
-    );
-  }
-}
+export default compose(
+  graphql(SIGNUP_USER, {
+    name: "signupUser"
+  }),
+  graphql(LOGIN_USER, {
+    name: "loginUser"
+  })
+)(SignupForm);

--- a/src/state/graphql-client/index.js
+++ b/src/state/graphql-client/index.js
@@ -1,11 +1,24 @@
 import ApolloClient, { InMemoryCache } from "apollo-boost";
+import { getToken } from "util/loginUtils";
 
 const cache = new InMemoryCache();
+
+const getHeaders = async () => {
+  const token = await getToken();
+  return token ? `Bearer ${token}` : null;
+};
 
 // Set up Apollo Apollo Client
 const client = new ApolloClient({
   cache,
   uri: "https://api.graph.cool/simple/v1/cjkbae1k593u7019023n2fxpo",
+  request: async operation => {
+    operation.setContext({
+      headers: {
+        authorization: await getHeaders()
+      }
+    });
+  },
   clientState: {
     defaults: {
       userInfo: {

--- a/src/state/mutations/index.jsx
+++ b/src/state/mutations/index.jsx
@@ -17,3 +17,25 @@ export const TOGGLE_TEST_AUTH = gql`
     ) @client
   }
 `;
+
+export const SIGNUP_USER = gql`
+  mutation signupUser($username: String!, $email: String!, $password: String!) {
+    createUser(
+      username: $username
+      authProvider: { email: { email: $email, password: $password } }
+    ) {
+      id
+    }
+  }
+`;
+
+export const LOGIN_USER = gql`
+  mutation loginUser($email: String!, $password: String!) {
+    signinUser(email: { email: $email, password: $password }) {
+      token
+      user {
+        username
+      }
+    }
+  }
+`;

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -18,6 +18,14 @@ export const StyledFormText = styled.p`
   text-align: center;
 `;
 
+export const StyledFormError = styled.p`
+  border: 1px solid black;
+  background-color: rgb(251, 245, 162);
+  padding: 5px;
+  margin: 0;
+  margin-bottom: 20px;
+`;
+
 export const StyledH2 = styled.h2`
   padding: 20px 0 0 20px;
   margin: 0;

--- a/src/util/catchGqlErrors.jsx
+++ b/src/util/catchGqlErrors.jsx
@@ -1,0 +1,15 @@
+const catchGqlErrors = err => {
+  const { graphQLErrors } = err;
+  console.log(graphQLErrors);
+  console.log(typeof graphQLErrors[0].code);
+  switch (graphQLErrors[0].code) {
+    case 3023:
+      return { username: "A user already exists with that information" };
+      break;
+    default:
+      return { username: "There was an unknown error." };
+  }
+  return null;
+};
+
+export default catchGqlErrors;

--- a/src/util/functions.js
+++ b/src/util/functions.js
@@ -21,3 +21,6 @@ export const switchPlural = n => (n > 1 ? "s" : "");
 export function dateToString(createdAt) {
   return new Date(createdAt).toLocaleDateString();
 }
+
+export { default as validateSignup } from "./validateSignup";
+export { default as catchGqlErrors } from "./catchGqlErrors";

--- a/src/util/loginUtils.jsx
+++ b/src/util/loginUtils.jsx
@@ -1,0 +1,16 @@
+let token;
+
+export const signIn = newToken => {
+  return localStorage.setItem("BEARER_TOKEN", newToken);
+};
+
+export const signOut = () => {
+  token = undefined;
+  return localStorage.removeItem("BEARER_TOKEN");
+};
+
+export const getToken = async () => {
+  if (token) return Promise.resolve(token);
+  token = await localStorage.getItem("BEARER_TOKEN");
+  return token;
+};

--- a/src/util/validateSignup.jsx
+++ b/src/util/validateSignup.jsx
@@ -1,0 +1,22 @@
+export default function validateSignup(values, props) {
+  const errors = {};
+  if (!values.username) errors.username = "Username is Required";
+  // If email is not present or badly formatted then return error
+  if (!values.email) {
+    errors.email = "Email Address is Required";
+  } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(values.email)) {
+    errors.email = "Invalid email address";
+  }
+  if (!values.password) errors.password = "Password is Required";
+  if (!values.passwordConf)
+    errors.passwordConf = "Password Confirmation is Required";
+  if (
+    values.passwordConf &&
+    values.password &&
+    values.passwordConf !== values.password
+  ) {
+    errors.password = "Password and Password Confirmation Must Match";
+    errors.passwordConf = "";
+  }
+  return errors;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,6 +466,12 @@ apollo-client@^2.3.2:
   optionalDependencies:
     "@types/async" "2.0.49"
 
+apollo-link-context@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/apollo-link-context/-/apollo-link-context-1.0.8.tgz#c967a56ac6ed32add748937735bcb57c5cc64c95"
+  dependencies:
+    apollo-link "^1.2.2"
+
 apollo-link-dedup@^1.0.0:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/apollo-link-dedup/-/apollo-link-dedup-1.0.9.tgz#3c4e4af88ef027cbddfdb857c043fd0574051dad"
@@ -2642,6 +2648,13 @@ create-react-class@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
+create-react-context@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-spawn@5.1.0, cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2913,6 +2926,10 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+deepmerge@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.1.tgz#e862b4e45ea0555072bf51e7fd0d9845170ae768"
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -3842,6 +3859,18 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fbjs@^0.8.0:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
+
 fbjs@^0.8.12, fbjs@^0.8.16, fbjs@^0.8.5, fbjs@^0.8.9:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -4024,6 +4053,20 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "1.0.6"
     mime-types "^2.1.12"
+
+formik@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-1.0.2.tgz#333962ab3f09f137992b13198fefa4ec91b15af5"
+  dependencies:
+    create-react-context "^0.2.2"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^2.5.5"
+    lodash.clonedeep "^4.5.0"
+    lodash.topath "4.5.2"
+    prop-types "^15.6.1"
+    react-fast-compare "^1.0.0"
+    tslib "^1.9.3"
+    warning "^3.0.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -4306,6 +4349,10 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+
 gzip-size@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-3.0.0.tgz#546188e9bdc337f673772f81660464b389dce520"
@@ -4452,6 +4499,10 @@ hoist-non-react-statics@1.x.x, hoist-non-react-statics@^1.2.0:
 hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
+
+hoist-non-react-statics@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -5866,6 +5917,10 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -5945,6 +6000,10 @@ lodash.templatesettings@^4.0.0:
 lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+
+lodash.topath@4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
 
 lodash.uniq@^4.5.0:
   version "4.5.0"
@@ -7609,6 +7668,10 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-fast-compare@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-1.0.0.tgz#813a039155e49b43ceffe99528fe5e9d97a6c938"
+
 react-fuzzy@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/react-fuzzy/-/react-fuzzy-0.5.2.tgz#fc13bf6f0b785e5fefe908724efebec4935eaefe"
@@ -9120,6 +9183,10 @@ tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
 
+tslib@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -9151,7 +9218,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-ua-parser-js@^0.7.9:
+ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"
 


### PR DESCRIPTION
**Summary of Changes**

- App now has a working auth with users able to create, login, and log out via email and password!
- Token is stored on localStorage until user signs out so login state persists on page refresh
- Pulled in Formik for SigninForm to standardize form building
- Attached bearer token to local storage and automatically retrieves token to place on graphql authorization headers. Crucial for protected actions e.g. updating a user post etc.

**To Do:**

- Use formik for LoginForm, New Posts, Comments, Group Creation etc.
- Clean up client state and remove test queries/mutations until we have a use for client state.