### PR TITLE
Fix group item in navigation to use IconNav and have a title.

### DIFF
--- a/src/components/atoms/Icons/Groups/index.jsx
+++ b/src/components/atoms/Icons/Groups/index.jsx
@@ -2,9 +2,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import { users } from "react-icons-kit/fa";
 
-import { IconBase } from "components/atoms";
+import { IconNav } from "components/atoms";
 
-const Groups = ({ title }) => <IconBase icon={users} title={title} />;
+const Groups = ({ title }) => <IconNav icon={users} title={title} />;
 
 Groups.propTypes = { title: PropTypes.string };
 Groups.defaultProps = { title: "Groups" };

--- a/src/components/organisms/NavBar/NavBar/RightNav.jsx
+++ b/src/components/organisms/NavBar/NavBar/RightNav.jsx
@@ -10,7 +10,7 @@ const RightNav = ({ user }) => {
   return (
     <StyledList>
       <ListLink to="/home" render={<HomeView />} />
-      <ListLink to="/groups" render={<Groups />} />
+      <ListLink to="/groups" render={<GroupView />} />
       {user ? <SubNavWithAuth {...user} /> : <SubNavNoAuth />}
     </StyledList>
   );
@@ -20,6 +20,13 @@ const HomeView = () => (
   <NavItemContainer>
     <Home />
     <TextVisibility>Home</TextVisibility>
+  </NavItemContainer>
+);
+
+const GroupView = () => (
+  <NavItemContainer>
+    <Groups />
+    <TextVisibility>Groups</TextVisibility>
   </NavItemContainer>
 );
 


### PR DESCRIPTION
Currently there is a weird floating Icon in the navbar, seems someone forgot to use `IconNav` and instead used `IconBase`

Also they were just sticking the icon in instead of a `ListItem` with the icon and name, so I fixed that too.